### PR TITLE
Fix gtg

### DIFF
--- a/main.go
+++ b/main.go
@@ -116,7 +116,7 @@ func main() {
 		servicesRouter.HandleFunc("/transformers/organisations/__ids", handler.getOrgIds).Methods("GET")
 		servicesRouter.HandleFunc("/transformers/organisations/__reload", handler.reloadOrgs).Methods("POST")
 
-		servicesRouter.HandleFunc("/transformers/organisations/{uuid:([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})}", handler.getOrgByUUID).Methods("GET")
+		servicesRouter.HandleFunc("/transformers/organisations/{uuid:[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}}", handler.getOrgByUUID).Methods("GET")
 		servicesRouter.HandleFunc("/transformers/organisations", handler.getOrgs).Methods("GET")
 
 		var h http.Handler = servicesRouter

--- a/service.go
+++ b/service.go
@@ -40,7 +40,7 @@ type orgServiceImpl struct {
 }
 
 func newOrgService(repo tmereader.Repository, baseURL string, taxonomyName string, maxTmeRecords int, cacheFileName string) orgsService {
-	s := &orgServiceImpl{repository: repo, baseURL: baseURL, taxonomyName: taxonomyName, maxTmeRecords: maxTmeRecords, initialised: true, dataLoaded: false, cacheFileName: cacheFileName}
+	s := &orgServiceImpl{repository: repo, baseURL: baseURL, taxonomyName: taxonomyName, maxTmeRecords: maxTmeRecords, initialised: false, dataLoaded: false, cacheFileName: cacheFileName}
 	go func(service *orgServiceImpl) {
 		err := service.init()
 		if err != nil {
@@ -105,7 +105,6 @@ func (s *orgServiceImpl) init() error {
 	var wg sync.WaitGroup
 	responseCount := 0
 
-	s.setDataLoaded(false)
 	log.Printf("Fetching organisations from TME\n")
 
 	err := s.openDB()
@@ -131,6 +130,7 @@ func (s *orgServiceImpl) init() error {
 
 	count, _ := s.orgCount()
 	s.setDataLoaded(true)
+	s.setInitialised(true)
 	log.Printf("Added %d orgs UUIDs\n", count)
 	return nil
 }
@@ -259,6 +259,7 @@ func (s *orgServiceImpl) orgIds() ([]orgUUID, error) {
 }
 
 func (s *orgServiceImpl) orgReload() error {
+	s.setDataLoaded(false)
 	err := s.shutdown()
 	if err != nil {
 		return err

--- a/service.go
+++ b/service.go
@@ -130,6 +130,7 @@ func (s *orgServiceImpl) init() error {
 	wg.Wait()
 
 	count, _ := s.orgCount()
+	s.setDataLoaded(true)
 	log.Printf("Added %d orgs UUIDs\n", count)
 	return nil
 }

--- a/service.go
+++ b/service.go
@@ -104,6 +104,7 @@ func (s *orgServiceImpl) openDB() error {
 func (s *orgServiceImpl) init() error {
 	var wg sync.WaitGroup
 	responseCount := 0
+	s.dataLoaded = false
 	log.Printf("Fetching organisations from TME\n")
 
 	err := s.openDB()

--- a/service.go
+++ b/service.go
@@ -104,7 +104,8 @@ func (s *orgServiceImpl) openDB() error {
 func (s *orgServiceImpl) init() error {
 	var wg sync.WaitGroup
 	responseCount := 0
-	s.dataLoaded = false
+
+	s.setDataLoaded(false)
 	log.Printf("Fetching organisations from TME\n")
 
 	err := s.openDB()


### PR DESCRIPTION
There was some issues reloading the v1 organisations - 

1. The gtg was good to go during reload
2. The reload was the old school version that waited until completion before returning a 200 rather than serving a 204 after initialisation of the reload. This was causing the concept publisher to send requests during reload which all were giving 404s as they hadn't been retrieved from TME yet

